### PR TITLE
fix: UPDATE_GPS 이벤트 바디에 토큰 추가

### DIFF
--- a/src/components/CreationButton.tsx
+++ b/src/components/CreationButton.tsx
@@ -1,5 +1,5 @@
-import { styled } from 'styled-components';
-import { Link } from 'react-router-dom';
+import { styled } from "styled-components";
+import { Link } from "react-router-dom";
 
 export default function CreationButton() {
   return (
@@ -13,7 +13,7 @@ export default function CreationButton() {
 }
 
 const StyledCreationButton = styled.img`
-  position: absolute;
+  position: fixed;
   width: 52px;
   height: 52px;
   bottom: 64px;

--- a/src/components/SockerProvider/index.tsx
+++ b/src/components/SockerProvider/index.tsx
@@ -1,26 +1,32 @@
-import React, { useCallback, useEffect, useRef } from 'react';
-import { useInterval } from 'react-use';
-import { SOCKET_MESSAGE } from '../../constants/socket';
-import { io } from 'socket.io-client';
+import React, { useCallback, useEffect, useRef } from "react";
+import { useInterval } from "react-use";
+import { SOCKET_MESSAGE } from "../../constants/socket";
+import { io } from "socket.io-client";
+import { getCookie } from "../../utils/cookie";
 
-export const socketIO = io(process.env.REACT_APP_SOCKET_URI ?? '', {
-  transports: ['websocket'],
+export const socketIO = io(process.env.REACT_APP_SOCKET_URI ?? "", {
+  transports: ["websocket"],
 });
 
 const SocketProvider = ({ children }: React.PropsWithChildren) => {
   const socket = useRef(socketIO);
+
   const updateGPSLocation = useCallback(async () => {
     const {
       coords: { latitude, longitude },
     } = await getGPSLocation();
+
     socketIO.emit(SOCKET_MESSAGE.UPDATE_GPS, {
       lat: latitude,
       long: longitude,
+      token: getCookie("accessToken"),
     });
   }, []);
 
   useEffect(() => {
-    socket.current.on(SOCKET_MESSAGE.CONNECT, () => updateGPSLocation());
+    socket.current.on(SOCKET_MESSAGE.CONNECT, () => {
+      updateGPSLocation();
+    });
   }, [updateGPSLocation]);
 
   useInterval(() => {

--- a/src/hooks/queries/useMemes.ts
+++ b/src/hooks/queries/useMemes.ts
@@ -1,41 +1,49 @@
-import { MEME_WIDTH_BY_SIZE } from './../../constants/index';
-import { useQuery } from '@tanstack/react-query';
-import QUERY_KEY from '../../constants/query';
-import { socketIO } from '../../components/SockerProvider';
-import { SOCKET_MESSAGE } from '../../constants/socket';
+import { MEME_WIDTH_BY_SIZE } from "./../../constants/index";
+import { useQuery } from "@tanstack/react-query";
+import QUERY_KEY from "../../constants/query";
+import { socketIO } from "../../components/SockerProvider";
+import { SOCKET_MESSAGE } from "../../constants/socket";
 
 const useMemes = () => {
-  const { data = [], isLoading } = useQuery(QUERY_KEY.MEMES, () => new Promise((res) => socketIO.on(SOCKET_MESSAGE.FETCH_MEMES, (memesRaw: MemeRaw[]) => {
-    const memes = (memesRaw ?? []).map<Meme>((meme) => {
-      let size: keyof typeof MEME_WIDTH_BY_SIZE;
-      if (meme.distance < 300) {
-        size = 'L'
-      } else if (meme.distance < 1000){
-        size = 'M';
-      } else {
-        size = 'S';
-      }
-      return ({
-        id: meme.memeId,
-        owner: meme.nickname,
-        ownerId: meme.creator,
-        updatorId: meme.updater,
-        createdTime: meme.createdTs,
-        updatedTime: meme.updatedTs,
-        ownerProfileURL: meme.profileImg,
-        size,
-        imageURL: meme.imgUrl,
-        text: meme.message,
-        stickers: meme.stickers,
-      });
-    });
-    res(memes);
-  })));
+  const { data = [], isLoading } = useQuery(
+    QUERY_KEY.MEMES,
+    () =>
+      new Promise((res) =>
+        socketIO.on(SOCKET_MESSAGE.FETCH_MEMES, (memesRaw: MemeRaw[]) => {
+          const memes = (memesRaw ?? []).map<Meme>((meme) => {
+            let size: keyof typeof MEME_WIDTH_BY_SIZE;
+
+            if (meme.distance < 300) {
+              size = "L";
+            } else if (meme.distance < 1000) {
+              size = "M";
+            } else {
+              size = "S";
+            }
+
+            return {
+              id: meme.memeId,
+              owner: meme.nickname,
+              ownerId: meme.creator,
+              updatorId: meme.updater,
+              createdTime: meme.createdTs,
+              updatedTime: meme.updatedTs,
+              ownerProfileURL: meme.profileImg,
+              size,
+              imageURL: meme.imgUrl,
+              text: meme.message,
+              stickers: meme.stickers,
+            };
+          });
+          res(memes);
+        })
+      )
+  );
 
   return {
     memes: data as Meme[],
     isLoading,
-  }
+  };
 };
 
 export default useMemes;

--- a/src/utils/createMeme.ts
+++ b/src/utils/createMeme.ts
@@ -19,13 +19,16 @@ export default async function createMeme(
       formData.append("message", text);
     }
 
-    const response: Response = await fetch("http://18.116.27.58:5000/memes", {
-      method: "POST",
-      headers: {
-        Authorization: `Bearer ${token}`,
-      },
-      body: formData,
-    });
+    const response: Response = await fetch(
+      `${process.env.REACT_APP_SERVER_URI}/memes`,
+      {
+        method: "POST",
+        headers: {
+          Authorization: `Bearer ${token}`,
+        },
+        body: formData,
+      }
+    );
 
     return response.json() as Promise<{
       result?: unknown;


### PR DESCRIPTION
메인에서 내가 만든 밈들을 불러올 수 없던 현상을 수정했습니다!

원인은 UPDATE_GPS 이벤트 발생 시 token 정보를 함께 실어주어야 서버에서 이에서 userId를 뽑아 해당 유저의 밈들을 가져올 수 있는데, 아직 token을 보내는 코드가 작성되어 있지 않아서 getCookie를 사용해 추가했습니다.