### PR TITLE
Feat/onboarding

### DIFF
--- a/src/components/MemeCreation/MemeTextInput.tsx
+++ b/src/components/MemeCreation/MemeTextInput.tsx
@@ -31,6 +31,7 @@ const StyledTextarea = styled.textarea`
   width: 100%;
   height: 100%;
   border: none;
+  border-radius: 0;
   resize: none;
   outline: none;
   color: white;

--- a/src/components/Onboarding/Onboarding.tsx
+++ b/src/components/Onboarding/Onboarding.tsx
@@ -11,7 +11,6 @@ interface TouchPosition {
 
 function Onboarding() {
   const [pageNumber, setPageNumber] = useState<number>(0);
-  // TODO: 수정하기
   const [className, setClassName] = useState<string>("");
   const [touchPosition, setTouchPosition] = useState<TouchPosition>({
     x: 0,
@@ -72,11 +71,11 @@ function Onboarding() {
         <Page
           image="/assets/images/detail-screen.png"
           description={`밈을 더 자세히 보고 \n 스티커로 공감해 보세요`}
-          button={
-            <StartButton handleStartButtonClick={handleStartButtonClick} />
-          }
         />
       </Pages>
+      {pageNumber === 2 && (
+        <StartButton handleStartButtonClick={handleStartButtonClick} />
+      )}
     </Container>
   );
 }
@@ -85,9 +84,10 @@ const Container = styled.div`
   display: flex;
   flex-direction: column;
   justify-content: center;
+  align-items: center;
   gap: 35px;
   width: 100%;
-  height: 100vh;
+  height: 100svh;
   background-color: #ffffff;
   position: absolute;
   z-index: 40;

--- a/src/components/Onboarding/Onboarding.tsx
+++ b/src/components/Onboarding/Onboarding.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useState, useEffect } from "react";
 import styled from "styled-components";
 import Page from "./Page";
 import StartButton from "./StartButton";
@@ -11,11 +11,16 @@ interface TouchPosition {
 
 function Onboarding() {
   const [pageNumber, setPageNumber] = useState<number>(0);
+  const [isLastPage, setIsLastPage] = useState<boolean>(false);
   const [className, setClassName] = useState<string>("");
   const [touchPosition, setTouchPosition] = useState<TouchPosition>({
     x: 0,
     y: 0,
   });
+
+  useEffect(() => {
+    setIsLastPage(pageNumber === 2);
+  }, [pageNumber]);
 
   const handleNextPage = () => {
     if (pageNumber >= 2) return;
@@ -73,7 +78,7 @@ function Onboarding() {
           description={`밈을 더 자세히 보고 \n 스티커로 공감해 보세요`}
         />
       </Pages>
-      {pageNumber === 2 && (
+      {isLastPage && (
         <StartButton handleStartButtonClick={handleStartButtonClick} />
       )}
     </Container>

--- a/src/components/Onboarding/Onboarding.tsx
+++ b/src/components/Onboarding/Onboarding.tsx
@@ -27,7 +27,7 @@ function Onboarding() {
     setPageNumber((prev) => prev - 1);
   };
 
-  const handleStartButtonClick = () => {
+  const handleClickStartButton = () => {
     localStorage.setItem("hasOnboarding", "true");
     setClassName("invisible");
   };
@@ -74,7 +74,7 @@ function Onboarding() {
         />
       </Pages>
       {pageNumber === 2 && (
-        <StartButton handleStartButtonClick={handleStartButtonClick} />
+        <StartButton handleClickStartButton={handleClickStartButton} />
       )}
     </Container>
   );

--- a/src/components/Onboarding/Onboarding.tsx
+++ b/src/components/Onboarding/Onboarding.tsx
@@ -27,7 +27,7 @@ function Onboarding() {
     setPageNumber((prev) => prev - 1);
   };
 
-  const handleClickStartButton = () => {
+  const handleStartButtonClick = () => {
     localStorage.setItem("hasOnboarding", "true");
     setClassName("invisible");
   };
@@ -74,7 +74,7 @@ function Onboarding() {
         />
       </Pages>
       {pageNumber === 2 && (
-        <StartButton handleClickStartButton={handleClickStartButton} />
+        <StartButton handleStartButtonClick={handleStartButtonClick} />
       )}
     </Container>
   );

--- a/src/components/Onboarding/Page.tsx
+++ b/src/components/Onboarding/Page.tsx
@@ -3,19 +3,15 @@ import styled from "styled-components";
 interface PageProps {
   image: string;
   description: string;
-  button?: JSX.Element;
 }
 
-function Page(props: PageProps) {
-  const { image, description, button } = props;
-
+function Page({ image, description }: PageProps) {
   return (
     <Container>
       <Description>{description}</Description>
       <Image>
         <img src={image} alt="onboarding" />
       </Image>
-      {button !== undefined && button}
     </Container>
   );
 }

--- a/src/components/Onboarding/StartButton.tsx
+++ b/src/components/Onboarding/StartButton.tsx
@@ -9,11 +9,12 @@ function StartButton({ handleStartButtonClick }: StartButtonProps) {
 }
 
 const Button = styled.button`
-  width: 100%;
+  width: calc(100% - 20px);
   height: 48px;
   border: none;
   border-radius: 12px;
-  margin-top: 20px;
+  position: absolute;
+  bottom: 10px;
   font-size: 18px;
   font-weight: 700;
   line-height: 48px;

--- a/src/components/Onboarding/StartButton.tsx
+++ b/src/components/Onboarding/StartButton.tsx
@@ -19,6 +19,7 @@ const Button = styled.button`
   line-height: 48px;
   color: #ffffff;
   background-color: #ff99f8;
+  cursor: pointer;
 `;
 
 export default StartButton;

--- a/src/components/Onboarding/StartButton.tsx
+++ b/src/components/Onboarding/StartButton.tsx
@@ -5,16 +5,40 @@ interface StartButtonProps {
 }
 
 function StartButton({ handleStartButtonClick }: StartButtonProps) {
-  return <Button onClick={handleStartButtonClick}>시작하기</Button>;
+  return (
+    <Background>
+      <Button onClick={handleStartButtonClick}>시작하기</Button>
+    </Background>
+  );
 }
 
+const Background = styled.div`
+  display: flex;
+  justify-content: center;
+  align-items: flex-end;
+  width: 100%;
+  height: 120px;
+  padding: 0 20px 20px 20px;
+  position: absolute;
+  bottom: 0;
+  background-color: #fff;
+  background: linear-gradient(
+    180deg,
+    rgba(255, 255, 255, 0) 0%,
+    rgba(255, 255, 255, 0.05) 3.65%,
+    rgba(255, 255, 255, 0.45) 10.42%,
+    rgba(255, 255, 255, 0.8) 16.67%,
+    rgba(255, 255, 255, 0.9) 19.79%,
+    #fff 25%,
+    #fff 100%
+  );
+`;
+
 const Button = styled.button`
-  width: calc(100% - 20px);
+  width: 100%;
   height: 48px;
   border: none;
   border-radius: 12px;
-  position: absolute;
-  bottom: 10px;
   font-size: 18px;
   font-weight: 700;
   line-height: 48px;

--- a/src/components/Onboarding/StartButton.tsx
+++ b/src/components/Onboarding/StartButton.tsx
@@ -1,13 +1,13 @@
 import styled from "styled-components";
 
 interface StartButtonProps {
-  handleClickStartButton: () => void;
+  handleStartButtonClick: () => void;
 }
 
-function StartButton({ handleClickStartButton }: StartButtonProps) {
+function StartButton({ handleStartButtonClick }: StartButtonProps) {
   return (
     <Background>
-      <Button onClick={handleClickStartButton}>시작하기</Button>
+      <Button onClick={handleStartButtonClick}>시작하기</Button>
     </Background>
   );
 }

--- a/src/components/Onboarding/StartButton.tsx
+++ b/src/components/Onboarding/StartButton.tsx
@@ -1,13 +1,13 @@
 import styled from "styled-components";
 
 interface StartButtonProps {
-  handleStartButtonClick: () => void;
+  handleClickStartButton: () => void;
 }
 
-function StartButton({ handleStartButtonClick }: StartButtonProps) {
+function StartButton({ handleClickStartButton }: StartButtonProps) {
   return (
     <Background>
-      <Button onClick={handleStartButtonClick}>시작하기</Button>
+      <Button onClick={handleClickStartButton}>시작하기</Button>
     </Background>
   );
 }

--- a/src/pages/MemeCreation.tsx
+++ b/src/pages/MemeCreation.tsx
@@ -103,7 +103,7 @@ const Container = styled.div`
   align-items: center;
   gap: 48px;
   width: 100%;
-  height: 100vh;
+  height: 100svh;
 `;
 
 const ButtonBackground = styled.div`


### PR DESCRIPTION
### 작업내용 
* 모바일 브라우저에서 세로 방향 스크롤 생기는 문제 해결 (100vh -> 100 svh)
* 모바일 브라우저에서 textarea에 border-radius가 생겨서 이 부분 수정했습니다. 
* 온보딩 화면 '시작하기' 버튼에 흰색 배경 추가했습니다. (휴대폰 이미지끼리 높이가 다른 문제 해결을 위해 버튼 position을 fixed로 바꿨고, 그랬더니 이미지와 버튼이 겹쳐서 배경을 넣었음) 

<img width="374" alt="스크린샷 2023-08-01 오후 6 34 44" src="https://github.com/Meme-dulecy/frontend/assets/77181642/ac400b47-cf36-4566-94ab-7a114ca23ef0">


### 특이사항 
* 모바일 브라우저에서 메인 페이지에 카드가 하나도 없을때 세로 스크롤이 생기는데, 테스트를 못해봐서 수정을 못했습니다. 